### PR TITLE
Okta Example Config and Minor change to connector_okta.py

### DIFF
--- a/examples/config files - basic/1 user-sync-config.yml
+++ b/examples/config files - basic/1 user-sync-config.yml
@@ -30,8 +30,10 @@ directory:
     # a dictionary for the actual configuration, or 
     # a string for the file containing the configuration, or
     # a list containing a mixture of dictionaries and strings
+    # okta example:
+    # okta: example.connector-okta.yml
     #
-    # examples:   
+    # ldap examples:
     # ldap: example.connector-ldap.yml
     # ldap: 
     #   - host: LDAP_host_URL_goes_here

--- a/examples/config files - basic/connector-okta.yml
+++ b/examples/config files - basic/connector-okta.yml
@@ -1,0 +1,27 @@
+okta_url: "Your Okta URL goes here ie. youcompany.okta.com"
+
+#For more detail on getting Okta API Token: http://developer.okta.com/docs/api/getting_started/getting_a_token.html
+api_token: "API token goes here"
+
+# specifies the string format used to construct a group query.
+# {group} is replaced with the name of the group to find.  Default is:
+# example for OKTA
+group_filter_format: "{group}"
+
+# specifies the string filter used to find all users in the directory.
+# For more detail: http://developer.okta.com/docs/api/resources/users.html#list-users-with-a-filter
+# Default, intending for Okta, is:
+all_users_filter: 'status eq "ACTIVE"'
+
+# specifies how an email address is retrieved in the system.
+# the string is a string format, with names enclosed by curly brackets replaced
+# by the corresponding attributes for a user. Default is:
+user_email_format: "{email}"
+
+# specifies the identity type of the dashboard user to create.
+# the valid values are: enterpriseID, federatedID
+#
+# If not specified, the default identity type from the main config file is used.
+#
+# example for enterprise ID:
+user_identity_type: federatedID

--- a/user_sync/connector/directory_okta.py
+++ b/user_sync/connector/directory_okta.py
@@ -74,8 +74,8 @@ class OktaDirectoryConnector(object):
         builder.set_string_value('logger_name', 'connector.' + OktaDirectoryConnector.name)
         builder.set_dict_value('source_filters', {})
 
-        okta_url = builder.require_string_value('okta_url')
-        api_key = builder.require_string_value('api_key')
+        okta_url = "https://" + builder.require_string_value('okta_url')
+        api_token = builder.require_string_value('api_token')
 
         options = builder.get_options()
 
@@ -103,8 +103,8 @@ class OktaDirectoryConnector(object):
         logger.info('Connecting to: %s', okta_url)
 
         try:
-            self.users_client =  okta.UsersClient(okta_url,api_key)
-            self.groups_client = okta.UserGroupsClient(okta_url, api_key)
+            self.users_client =  okta.UsersClient(okta_url,api_token)
+            self.groups_client = okta.UserGroupsClient(okta_url, api_token)
         except Exception as e:
             raise user_sync.error.AssertionException(repr(e))
 


### PR DESCRIPTION
- Minor changes to connector_okta.py See Issue #5 
   - Concat Https to okta_url
   - Change variable name api_key -> api_token to match with Okta terminology.

- Added Example config for Okta. Resolved #11 