### PR TITLE
added Test case for OKTAValueFormatter class

### DIFF
--- a/tests/connector/directory_okta_test.py
+++ b/tests/connector/directory_okta_test.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2016-2017 Adobe Systems Incorporated.  All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+import unittest
+
+from user_sync.connector.directory_okta import OKTAValueFormatter
+class TestOKTAValueFormatter(unittest.TestCase):
+    def test_get_extended_attribute_dict(self):
+        print 'Used to compare input and expected output data after OKTA formatting def Call'
+        attributes = ['firstName', 'lastName', 'login', 'email', 'countryCode']
+        expectedresult = str('''{'countryCode': <type 'str'>, 'lastName': <type 'str'>, 'login': <type 'str'>, 'email': <type 'str'>, 'firstName': <type 'str'>}''')
+
+        self.assertEqual(expectedresult, str(OKTAValueFormatter.get_extended_attribute_dict(attributes)), 'Getting expected Output')
+		
+		
+		
+		
+		


### PR DESCRIPTION
use case: Used to compare input and expected output data after OKTAValueFormatter get_extended_attribute_dict() called